### PR TITLE
Mutable test registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ A minimal test module calls `setup` and uses the resulting `test` function to cr
 ```ts
 import { setup, assertions } from "inertion";
 
-const test = setup(assertions);
+export const test = setup(assertions);
 
-export default test(`hello world`, async is => {
+test(`hello world`, async is => {
   is.ok(true, "all good");
   is.equal(1, 2, "oh no, so wrong");
 });
@@ -73,16 +73,16 @@ export default test(`hello world`, async is => {
 
 ### What does an entry script look like?
 
-A minimal test script will `run` the tests, and then , and will most
+A minimal test script will `run` the tests, and then most
 likely exit with `statusOf(results)`:
 
 ```ts
 import { run } from "inertion";
 import { printReport, statusOf } from "inertion";
-import helloWorld from "./hello.test.ts";
+import test from "./hello.test.ts";
 
 (async () => {
-  const results = await run([helloWorld]);
+  const results = await run(test);
 
   printReport(results);
 
@@ -97,13 +97,13 @@ You can provide a context factory to `setup` - every test will receive a new con
 ```ts
 import { setup, assertions } from "inertion";
 
-const test = setup(assertions, () => ({
+export const test = setup(assertions, () => ({
   get testSubject() {
     return new TestSubject("abc", [1,2,3]);
   }
 }));
 
-export default test(`hello world`, async (is, { testSubject }) => {
+test(`hello world`, async (is, { testSubject }) => {
   is.ok(testSubject instanceof TestSubject, "all good");
 });
 ```

--- a/examples/basic/src/add.test.js
+++ b/examples/basic/src/add.test.js
@@ -1,8 +1,8 @@
 import { setup, assertions } from "inertion";
 import { add } from "./add.js";
 
-const test = setup(assertions);
+export const test = setup(assertions);
 
-export default test(`can add numbers`, async is => {
+test(`can add numbers`, async is => {
   is.equal(add(1, 2), 3);
 });

--- a/examples/basic/test.js
+++ b/examples/basic/test.js
@@ -1,10 +1,8 @@
-import { run } from "inertion";
-import { printReport, statusOf } from "inertion";
+import { run, printReport, statusOf } from "inertion";
+import { test } from "./src/add.test.js";
 
 (async () => {
-  const results = await run([
-    (await import("./src/add.test.js")).default,
-  ]);
+  const results = await run(test);
 
   printReport(results);
 

--- a/examples/typescript/src/add.test.ts
+++ b/examples/typescript/src/add.test.ts
@@ -1,8 +1,8 @@
 import { setup, assertions } from "inertion";
 import { add } from "./add";
 
-const test = setup(assertions);
+export const test = setup(assertions);
 
-export default test(`can add numbers`, async is => {
+test(`can add numbers`, async is => {
   is.equal(add(1, 2), 3);
 });

--- a/examples/typescript/test.ts
+++ b/examples/typescript/test.ts
@@ -1,9 +1,8 @@
 import { run, printReport, statusOf } from "inertion";
+import { test } from "./src/add.test";
 
 (async () => {
-  const results = await run([
-    (await import("./src/add.test")).default,
-  ]);
+  const results = await run(test);
 
   printReport(results);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inertion",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "repository": "github:mindplay-dk/inertion",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,9 +10,11 @@ export type TestMethod = {
 
 export type ContextFactory<T> = () => T;
 
-export type TestFactory<T extends MethodMap, C> = {
-  (description: string, spec: Spec<T, C>): Test<T, C>;
+export type TestRegistry<T extends MethodMap, C> = {
+  (description: string, spec: Spec<T, C>): void;
 }
+
+export type TestSuite<T extends MethodMap, C> = Iterable<Test<T, C>>;
 
 export type Spec<T extends MethodMap, C> = {
   (tester: Tester<T>, context: C): Promise<void>;

--- a/test/cases.ts
+++ b/test/cases.ts
@@ -1,16 +1,16 @@
 import { assertion, assertions } from "../src/assertions";
 import { setup } from "../src/harness";
 
-const even = assertion("even", (num: number) => num % 2 === 0);
+export const passingTest = setup(assertions);
 
-const test = setup({ ...assertions, even });
-
-export const passingTest = test(`this is a test`, async is => {
+passingTest(`this is a test`, async is => {
   is.equal(1, 1, "one is one");
   is.ok(true, "true is true");
 });
 
-export const failingTest = test(`this is another test`, async is => {
+export const failingTest = setup(assertions);
+
+failingTest(`this is another test`, async is => {
   is.ok(true, "this will succeed");
   is.ok(false, "this will fail");
 });
@@ -20,20 +20,30 @@ export const createTestWithContext = () => {
 
   const test = setup(assertions, () => ({ number: number++ }));
 
-  return test(`test with context`, async (is, { number }) => {
+  test(`test with context`, async (is, { number }) => {
     is.equal(number, number);
   });
+
+  return test;
 }
 
-export const createTestWithCustomAssertion = test(`custom assertion`, async is => {
+const even = assertion("even", (num: number) => num % 2 === 0);
+
+export const testWithCustomAssertion = setup({ ...assertions, even })
+
+testWithCustomAssertion(`custom assertion`, async is => {
   is.even(2, "ok", "sure");
   is.even(1, "nope");
 });
 
-export const testWithUnexpectedError = test(`unexpected error`, async is => {
+export const testWithUnexpectedError = setup({});
+
+testWithUnexpectedError(`unexpected error`, async is => {
   throw new Error(`oh no`);
 });
 
-export const testWithUnexpectedUnknownError = test(`unexpected unknown error`, async is => {
+export const testWithUnexpectedUnknownError = setup({});
+
+testWithUnexpectedUnknownError(`unexpected unknown error`, async is => {
   throw "oh no";
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -3,336 +3,336 @@ import { Result } from "../src/api";
 import { assertions, createAssertions } from "../src/assertions";
 import { run, setup, UnknownError } from "../src/harness";
 import { printReport, isSuccess, statusOf } from "../src/reporting";
-import { failingTest, passingTest, createTestWithContext, createTestWithCustomAssertion, testWithUnexpectedError, testWithUnexpectedUnknownError } from "./cases";
+import { failingTest, passingTest, createTestWithContext, testWithCustomAssertion, testWithUnexpectedError, testWithUnexpectedUnknownError } from "./cases";
 import { isSameType } from "../src/is-same-type";
 import validator from "validator";
 
 const test = setup(assertions);
 
-(async () => {
-  const results = await run([
-    test(`can run passing and failing tests`, async is => {
-      const expectedFromPassingTest: Omit<Result, "time"> = {
-        description: "this is a test",
-        error: undefined,
-        checks: [
-          {
-            location: "/home/mindplay/workspace/funky-test/test/cases.ts:9:6",
-            fact: {
-              label: "equal",
-              pass: true,
-              actual: 1,
-              expected: 1,
-              details: ["one is one"],
-            },
-          },
-          {
-            location: "/home/mindplay/workspace/funky-test/test/cases.ts:10:6",
-            fact: {
-              label: "ok",
-              pass: true,
-              actual: true,
-              expected: true,
-              details: ["true is true"],
-            },
-          },
-        ],
-      };
-      
-      const expectedFromFailingTest: Omit<Result, "time"> = {
-        description: "this is another test",
-        error: undefined,
-        checks: [
-          {
-            location: "/home/mindplay/workspace/funky-test/test/cases.ts:14:6",
-            fact: {
-              label: "ok",
-              pass: true,
-              actual: true,
-              expected: true,
-              details: ["this will succeed"],
-            },
-          },
-          {
-            location: "/home/mindplay/workspace/funky-test/test/cases.ts:15:6",
-            fact: {
-              label: "ok",
-              pass: false,
-              actual: false,
-              expected: true,
-              details: ["this will fail"],
-            },
-          },
-        ],
-      };      
-    
-      const results = await run([passingTest, failingTest]);
-    
-      const checkedResults = results.map(({ time, ...rest }) => {
-        is.ok(time >= 0, "it produces a time value");
-    
-        return rest;
-      });
-
-      is.equal(checkedResults, [expectedFromPassingTest, expectedFromFailingTest], "it produces the expected test results");
-    
-      is.equal(isSuccess(results), false, "isSuccess() returns false when any tests fail");
-    }),
-
-    test(`can run passing test`, async is => {
-      const results = await run([passingTest]);
-    
-      is.equal(isSuccess(results), true, "isSuccess() returns true when all tests succeed");
-    }),
-
-    test(`can create unique contexts`, async is => {
-      const testWithContext = createTestWithContext();
-
-      const results = await run([testWithContext, testWithContext]);
-
-      is.equal(results[0].checks[0].fact.actual, 1);
-      is.equal(results[1].checks[0].fact.actual, 2);
-    }),
-
-    test(`can bootstrap test-methods from assertions`, async is => {
-      const result = await run([createTestWithCustomAssertion]);
-
-      is.equal(
-        result.map(({ time, ...rest }) => rest),
-        [
-          {
-            description: 'custom assertion',
-            checks: [
-              {
-                location: '/home/mindplay/workspace/funky-test/test/cases.ts:29:6',
-                fact: {
-                  label: 'even',
-                  pass: true,
-                  actual: 2,
-                  details: ['ok', 'sure']
-                }
-              },
-              {
-                location: '/home/mindplay/workspace/funky-test/test/cases.ts:30:6',
-                fact: {
-                  label: 'even',
-                  pass: false,
-                  actual: 1,
-                  details: ['nope']
-                }
-              }
-            ],
-            error: undefined
-          }
-        ]
-      );
-    }),
-
-    test(`ok/notOk assertions make strict boolean comparisons`, async is => {
-      const a = {}, b = {};
-
-      is.equal(
-        assertions.ok(true, a, b),
-        { label: "ok", pass: true, actual: true, expected: true, details: [a, b] }
-      );
-
-      is.equal(
-        assertions.notOk(false, a, b),
-        { label: "notOk", pass: true, actual: false, expected: false, details: [a, b] }
-      );
-
-      const nonBooleans: any[] = ["false", "true", 1, 0, null, undefined, {}];
-
-      for (const actual of nonBooleans) {
-        is.equal(
-          assertions.ok(actual, a, b),
-          { label: "ok", pass: false, actual, expected: true, details: [a, b] }
-        );
+test(`can run passing and failing tests`, async is => {
+  const expectedFromPassingTest: Omit<Result, "time"> = {
+    description: "this is a test",
+    error: undefined,
+    checks: [
+      {
+        location: "/home/mindplay/workspace/funky-test/test/cases.ts:7:6",
+        fact: {
+          label: "equal",
+          pass: true,
+          actual: 1,
+          expected: 1,
+          details: ["one is one"],
+        },
+      },
+      {
+        location: "/home/mindplay/workspace/funky-test/test/cases.ts:8:6",
+        fact: {
+          label: "ok",
+          pass: true,
+          actual: true,
+          expected: true,
+          details: ["true is true"],
+        },
+      },
+    ],
+  };
   
-        is.equal(
-          assertions.notOk(actual, a, b),
-          { label: "notOk", pass: false, actual, expected: false, details: [a, b] }
-        );
+  const expectedFromFailingTest: Omit<Result, "time"> = {
+    description: "this is another test",
+    error: undefined,
+    checks: [
+      {
+        location: "/home/mindplay/workspace/funky-test/test/cases.ts:14:6",
+        fact: {
+          label: "ok",
+          pass: true,
+          actual: true,
+          expected: true,
+          details: ["this will succeed"],
+        },
+      },
+      {
+        location: "/home/mindplay/workspace/funky-test/test/cases.ts:15:6",
+        fact: {
+          label: "ok",
+          pass: false,
+          actual: false,
+          expected: true,
+          details: ["this will fail"],
+        },
+      },
+    ],
+  };      
+
+  const results = await run(passingTest, failingTest);
+
+  const checkedResults = results.map(({ time, ...rest }) => {
+    is.ok(time >= 0, "it produces a time value");
+
+    return rest;
+  });
+
+  is.equal(checkedResults, [expectedFromPassingTest, expectedFromFailingTest], "it produces the expected test results");
+
+  is.equal(isSuccess(results), false, "isSuccess() returns false when any tests fail");
+});
+
+test(`can run passing test`, async is => {
+  const results = await run(passingTest);
+
+  is.equal(isSuccess(results), true, "isSuccess() returns true when all tests succeed");
+});
+
+test(`can create unique contexts`, async is => {
+  const testWithContext = createTestWithContext();
+
+  const results = await run(testWithContext, testWithContext);
+
+  is.equal(results[0].checks[0].fact.actual, 1);
+  is.equal(results[1].checks[0].fact.actual, 2);
+});
+
+test(`can bootstrap test-methods from assertions`, async is => {
+  const result = await run(testWithCustomAssertion);
+
+  is.equal(
+    result.map(({ time, ...rest }) => rest),
+    [
+      {
+        description: 'custom assertion',
+        checks: [
+          {
+            location: '/home/mindplay/workspace/funky-test/test/cases.ts:35:6',
+            fact: {
+              label: 'even',
+              pass: true,
+              actual: 2,
+              details: ['ok', 'sure']
+            }
+          },
+          {
+            location: '/home/mindplay/workspace/funky-test/test/cases.ts:36:6',
+            fact: {
+              label: 'even',
+              pass: false,
+              actual: 1,
+              details: ['nope']
+            }
+          }
+        ],
+        error: undefined
       }
-    }),
-    
-    test(`same/notSame assertions make strict (identity) comparisons`, async is => {
-      const a = { a: 1 }, b = { a: 1 };
+    ]
+  );
+});
 
-      const same: [any, any][] = [
-        [a, a],
-        [null, null],
-        [true, true],
-        [false, false],
-        ["aaa", "aaa"],
-        [NaN, NaN]
-      ];
+test(`ok/notOk assertions make strict boolean comparisons`, async is => {
+  const a = {}, b = {};
 
-      for (const [actual, expected] of same) {
-        is.equal(
-          assertions.same(actual, expected, a, b),
-          { label: "same", pass: true, actual, expected, details: [a, b] }
-        );
+  is.equal(
+    assertions.ok(true, a, b),
+    { label: "ok", pass: true, actual: true, expected: true, details: [a, b] }
+  );
 
-        is.equal(
-          assertions.notSame(actual, expected, a, b),
-          { label: "notSame", pass: false, actual, expected, details: [a, b] }
-        );
-      }
+  is.equal(
+    assertions.notOk(false, a, b),
+    { label: "notOk", pass: true, actual: false, expected: false, details: [a, b] }
+  );
 
-      const notSame: [any, any][] = [
-        [a, b],
-        [null, undefined],
-        ["aaa", "bbb"],
-        [+0, -0],
-      ];
+  const nonBooleans: any[] = ["false", "true", 1, 0, null, undefined, {}];
 
-      for (const [actual, expected] of notSame) {
-        is.equal(
-          assertions.same(actual, expected, a, b),
-          { label: "same", pass: false, actual, expected, details: [a, b] }
-        );
+  for (const actual of nonBooleans) {
+    is.equal(
+      assertions.ok(actual, a, b),
+      { label: "ok", pass: false, actual, expected: true, details: [a, b] }
+    );
 
-        is.equal(
-          assertions.notSame(actual, expected, a, b),
-          { label: "notSame", pass: true, actual, expected, details: [a, b] }
-        );
-      }
-    }),
+    is.equal(
+      assertions.notOk(actual, a, b),
+      { label: "notOk", pass: false, actual, expected: false, details: [a, b] }
+    );
+  }
+});
 
-    test(`equal/notEqual assertions make deep comparisons (using fast-deep-equal)`, async is => {
-      // NOTE: this test is non-exhaustive, since `fast-deep-equal` is well tested already.
-      
-      const a = {}, b = {};
+test(`same/notSame assertions make strict (identity) comparisons`, async is => {
+  const a = { a: 1 }, b = { a: 1 };
 
-      const equals: [any, any][] = [
-        [1, 1],
-        ["aaa", "aaa"],
-        [{}, {}],
-        [{ a: 1, b: "bbb", c: [1, 2] }, { a: 1, b: "bbb", c: [1, 2] }],
-      ];
+  const same: [any, any][] = [
+    [a, a],
+    [null, null],
+    [true, true],
+    [false, false],
+    ["aaa", "aaa"],
+    [NaN, NaN]
+  ];
 
-      for (const [actual, expected] of equals) {
-        is.equal(
-          assertions.equal(actual, expected, a, b),
-          { label: "equal", pass: true, actual, expected, details: [a, b] },
-        );  
+  for (const [actual, expected] of same) {
+    is.equal(
+      assertions.same(actual, expected, a, b),
+      { label: "same", pass: true, actual, expected, details: [a, b] }
+    );
 
-        is.equal(
-          assertions.notEqual(actual, expected, a, b),
-          { label: "notEqual", pass: false, actual, expected, details: [a, b] },
-        );
-      }
+    is.equal(
+      assertions.notSame(actual, expected, a, b),
+      { label: "notSame", pass: false, actual, expected, details: [a, b] }
+    );
+  }
 
-      const nonEquals: [any, any][] = [
-        [1, 2],
-        ["aaa", "bbb"],
-        [{}, { a: 1 }],
-        [{ a: 1, b: "bbb", c: [1, 2] }, { a: 2, b: "bbb", c: [1, 2] }],
-        [{ a: 1, b: "bbb", c: [1, 2] }, { a: 1, b: "bbb", c: [1] }],
-      ];
+  const notSame: [any, any][] = [
+    [a, b],
+    [null, undefined],
+    ["aaa", "bbb"],
+    [+0, -0],
+  ];
 
-      for (const [actual, expected] of nonEquals) {
-        is.equal(
-          assertions.equal(actual, expected, a, b),
-          { label: "equal", pass: false, actual, expected, details: [a, b] },
-        );  
+  for (const [actual, expected] of notSame) {
+    is.equal(
+      assertions.same(actual, expected, a, b),
+      { label: "same", pass: false, actual, expected, details: [a, b] }
+    );
 
-        is.equal(
-          assertions.notEqual(actual, expected, a, b),
-          { label: "notEqual", pass: true, actual, expected, details: [a, b] },
-        );
-      }
-    }),
+    is.equal(
+      assertions.notSame(actual, expected, a, b),
+      { label: "notSame", pass: true, actual, expected, details: [a, b] }
+    );
+  }
+});
 
-    test(`can manually pass or fail tests`, async is => {
-      const a = {}, b = {};
+test(`equal/notEqual assertions make deep comparisons (using fast-deep-equal)`, async is => {
+  // NOTE: this test is non-exhaustive, since `fast-deep-equal` is well tested already.
+  
+  const a = {}, b = {};
 
-      is.equal(
-        assertions.passed(a, b),
-        { label: "passed", pass: true, details: [a, b] },
-      );
+  const equals: [any, any][] = [
+    [1, 1],
+    ["aaa", "aaa"],
+    [{}, {}],
+    [{ a: 1, b: "bbb", c: [1, 2] }, { a: 1, b: "bbb", c: [1, 2] }],
+  ];
 
-      is.equal(
-        assertions.failed(a, b),
-        { label: "failed", pass: false, details: [a, b] },
-      );
-    }),
+  for (const [actual, expected] of equals) {
+    is.equal(
+      assertions.equal(actual, expected, a, b),
+      { label: "equal", pass: true, actual, expected, details: [a, b] },
+    );  
 
-    test(`can capture unexpected errors`, async is => {
-      const results = await run([testWithUnexpectedError, testWithUnexpectedUnknownError]);
+    is.equal(
+      assertions.notEqual(actual, expected, a, b),
+      { label: "notEqual", pass: false, actual, expected, details: [a, b] },
+    );
+  }
 
-      is.ok(results[0].error instanceof Error);
-      is.ok(results[1].error instanceof UnknownError, "it should convert unknown error types to UnknownError instances");
-    }),
+  const nonEquals: [any, any][] = [
+    [1, 2],
+    ["aaa", "bbb"],
+    [{}, { a: 1 }],
+    [{ a: 1, b: "bbb", c: [1, 2] }, { a: 2, b: "bbb", c: [1, 2] }],
+    [{ a: 1, b: "bbb", c: [1, 2] }, { a: 1, b: "bbb", c: [1] }],
+  ];
 
-    test(`can test for same types`, async is => {
-      class A {}
-      class B extends A {}
+  for (const [actual, expected] of nonEquals) {
+    is.equal(
+      assertions.equal(actual, expected, a, b),
+      { label: "equal", pass: false, actual, expected, details: [a, b] },
+    );  
 
-      /**
-       * Tuples of same-type values
-       */
-      const values: unknown[][] = [
-        [1, 0.0, NaN],   // all numbers are numbers (even NaN)
-        ["a", ""],       // empty string is a string
-        [null],          // null is a distinct type
-        [undefined],     // undefined is a distinct type
-        [{}, { a: 1 }],  // all POJOs are the same type
-        [new A()],       // classes have distinct types
-        [new B()],       // every class is distinct
-        [[], [1, 2, 3]], // all arrays are the same type
-        [Symbol("a")],   // Symbols represent distinct types (see `unique symbol` in TypeScript)
-        [Symbol("a")],   // even similar Symbols have distinct types
-        // all functions are regarded as the same type:
-        [A, B, function () {}, () => {}, async function () {}, async () => {}],
-      ];
+    is.equal(
+      assertions.notEqual(actual, expected, a, b),
+      { label: "notEqual", pass: true, actual, expected, details: [a, b] },
+    );
+  }
+});
 
-      values.forEach((as, indexA) => {
-        values.forEach((bs, indexB) => {
-          as.forEach(a => {
-            bs.forEach(b => {
-              if (indexA === indexB) {
-                is.ok(isSameType(a, b), "same types", a, b);
-              } else {
-                is.ok(! isSameType(a, b), "not same types", a, b);
-              }
-            });
-          });
+test(`can manually pass or fail tests`, async is => {
+  const a = {}, b = {};
+
+  is.equal(
+    assertions.passed(a, b),
+    { label: "passed", pass: true, details: [a, b] },
+  );
+
+  is.equal(
+    assertions.failed(a, b),
+    { label: "failed", pass: false, details: [a, b] },
+  );
+});
+
+test(`can capture unexpected errors`, async is => {
+  const results = await run(testWithUnexpectedError, testWithUnexpectedUnknownError);
+
+  is.ok(results[0].error instanceof Error);
+  is.ok(results[1].error instanceof UnknownError, "it should convert unknown error types to UnknownError instances");
+});
+
+test(`can test for same types`, async is => {
+  class A {}
+  class B extends A {}
+
+  /**
+   * Tuples of same-type values
+   */
+  const values: unknown[][] = [
+    [1, 0.0, NaN],   // all numbers are numbers (even NaN)
+    ["a", ""],       // empty string is a string
+    [null],          // null is a distinct type
+    [undefined],     // undefined is a distinct type
+    [{}, { a: 1 }],  // all POJOs are the same type
+    [new A()],       // classes have distinct types
+    [new B()],       // every class is distinct
+    [[], [1, 2, 3]], // all arrays are the same type
+    [Symbol("a")],   // Symbols represent distinct types (see `unique symbol` in TypeScript)
+    [Symbol("a")],   // even similar Symbols have distinct types
+    // all functions are regarded as the same type:
+    [A, B, function () {}, () => {}, async function () {}, async () => {}],
+  ];
+
+  values.forEach((as, indexA) => {
+    values.forEach((bs, indexB) => {
+      as.forEach(a => {
+        bs.forEach(b => {
+          if (indexA === indexB) {
+            is.ok(isSameType(a, b), "same types", a, b);
+          } else {
+            is.ok(! isSameType(a, b), "not same types", a, b);
+          }
         });
       });
-    }),
+    });
+  });
+});
 
-    test(`can map predicates to assertions`, async is => {
-      const a = createAssertions({
-        truthy(value: unknown) {
-          return !!value;
-        },
-        falsy(value: unknown) {
-          return !value;
-        }
-      });
+test(`can map predicates to assertions`, async is => {
+  const a = createAssertions({
+    truthy(value: unknown) {
+      return !!value;
+    },
+    falsy(value: unknown) {
+      return !value;
+    }
+  });
 
-      is.equal(a.truthy(true).label, "truthy");
-      is.equal(a.falsy(false).label, "falsy");
-      is.equal(a.truthy(true).actual, true);
-      is.equal(a.truthy(false).actual, false);
-      is.equal(a.truthy(true).expected, undefined, "predicates have no expected value");
-      is.equal(a.truthy(true).details, []);
-      is.equal(a.truthy(true, 1, 2).details, [1, 2]);
-      is.equal(a.truthy(true).pass, true);
-      is.equal(a.truthy(false).pass, false);
-    }),
+  is.equal(a.truthy(true).label, "truthy");
+  is.equal(a.falsy(false).label, "falsy");
+  is.equal(a.truthy(true).actual, true);
+  is.equal(a.truthy(false).actual, false);
+  is.equal(a.truthy(true).expected, undefined, "predicates have no expected value");
+  is.equal(a.truthy(true).details, []);
+  is.equal(a.truthy(true, 1, 2).details, [1, 2]);
+  is.equal(a.truthy(true).pass, true);
+  is.equal(a.truthy(false).pass, false);
+});
 
-    test(`can use a third-party validator library`, async is => {
-      const a = createAssertions(validator);
+test(`can use a third-party validator library`, async is => {
+  const a = createAssertions(validator);
 
-      is.equal(a.isCreditCard("4929 7226 5379 7141").pass, true);
-      is.equal(a.isCreditCard("4929 7226 5379 7149").pass, false);
+  is.equal(a.isCreditCard("4929 7226 5379 7141").pass, true);
+  is.equal(a.isCreditCard("4929 7226 5379 7149").pass, false);
 
-      is.equal((a as any).version, undefined, "non-function properties are omitted");
-    }),
-  ]);
+  is.equal((a as any).version, undefined, "non-function properties are omitted");
+});
+
+(async () => {
+  const results = await run(test);
 
   printReport(results);
 


### PR DESCRIPTION
Exploring more traditional ergonomics, this change deviates somewhat from my stated objective of using pure functions. 🤔

### Ergonomics

Before this change, tests were *individually* imported or exported, independently of the `test` harness you created with `setup`:

https://github.com/mindplay-dk/inertion/blob/6209254cf8ed5ff1cd0c3a2027f0f3522ea759d0/examples/basic/src/add.test.js#L4-L8

With this change, test modules export the `test` harness itself - not the individual tests:

https://github.com/mindplay-dk/inertion/blob/1021ab228f5846e91ccb59b8d82faf28ca976a08/examples/basic/src/add.test.js#L4-L8

The `test` harness is essentially a mutable array - when you call `test`, you push a test into the array, and when you pass the `test` to the `run` function, it iterates over the individual `Test` instances inside it.

### Types

In terms of types, the `test` harness created by `setup` was previously just a `TestFactory` for `Test` instances:

https://github.com/mindplay-dk/inertion/blob/6209254cf8ed5ff1cd0c3a2027f0f3522ea759d0/src/api.ts#L13-L15

With this change, the `test` harness is now a combined `TestRegistry` and iterable `TestSuite` in one:

https://github.com/mindplay-dk/inertion/blob/1021ab228f5846e91ccb59b8d82faf28ca976a08/src/api.ts#L13-L17

The `test` harness produced by `setup` now doubles as a test "suite" (list of tests) and a mutable "registry".

### Conclusions

The previous approach apparently was difficult for some people to follow - if you're used to the style of mainstream test frameworks, essentially everything is mutable, global state; the `test` function "just works".

The previous approach was pure (no side effects) but perhaps impractical: if you had more than one test in the same module (which is typical) you either had to name the individual exports, or perhaps jam them into an array. Your tests already have descriptions in plain text - having to assign names to individual tests, or building arrays of tests, may have seemed burdensome.

So the downside to this change is side-effects, which don't generally help with understanding - you might look at a call like `test("hello", async is => { ... })` and without an understanding of what this function does, it's not clear what happens to the function and description you just passed.

Perhaps, in this case, that's a minor issue, as almost anyone with test experience will be familiar with similar patterns - pure functions may not match the expectations of the audience here.

(Note that `setup` and `run` are still pure functions - this change only introduces a mutable test registry in favor of convenience. I have no plans to introduce a global registry, or make tests automatically run; the goal is still a test library, not a framework. This change does not limit your options in terms of having multiple harnesses with different assertions and contexts, etc.)
